### PR TITLE
Fixes for autoregen.sh with automake 1.15

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -22,6 +22,7 @@
 
 # Run autoreconf
 mkdir -p m4
+mkdir -p lib/cache_sim/m4
 mkdir -p config
 aclocal -I m4 --install
 autoreconf -ivf --warnings=all,no-obsolete,no-override -I config

--- a/tools/macpo/Makefile.am
+++ b/tools/macpo/Makefile.am
@@ -19,6 +19,8 @@
 # $HEADER$
 #
 
+AUTOMAKE_OPTIONS = subdir-objects
+
 SUBDIRS = libmacpo inst libmrt analyze libset
 dist_bin_SCRIPTS = macpo.sh
 

--- a/tools/macpo/libset/Makefile.am
+++ b/tools/macpo/libset/Makefile.am
@@ -19,6 +19,8 @@
 # $HEADER$
 #
 
+AUTOMAKE_OPTIONS = subdir-objects
+
 lib_LTLIBRARIES = libset.la 
 
 libset_la_SOURCES = ../analyze/cache_info.cpp set_cache_conflict_lib.cpp


### PR DESCRIPTION
These changes fix autogen.sh failures for me, with automake 1.15.

"Build my own perfexpert installation on some non-TACC systems" has been on my todo list for quite a while; I wish a better reminder had finally gotten me started.

My condolences to Dr. Browne's friends.  I never got to know him well, so I won't be at his wake, and "submitted a PR in memoriam" seems like a nerdy/tacky alternative... but if any of the developers here are in attendance, please let his other friends and family know that even his briefest acquaintances think the world will be worse with him gone.